### PR TITLE
Changes to sgx vm

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
-name = "autocfg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
 name = "backtrace"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,16 +74,6 @@ name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "bincode"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
-dependencies = [
- "byteorder",
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -190,15 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,13 +221,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-vm"
+name = "cosmwasm-sgx-vm"
 version = "0.7.0"
 dependencies = [
  "blake3",
  "cosmwasm",
+ "downcast-rs",
  "enclave-ffi-types",
- "hex 0.3.2",
+ "hex",
  "lru",
  "memmap",
  "parity-wasm",
@@ -263,116 +239,6 @@ dependencies = [
  "snafu",
  "tempfile",
  "wabt",
- "wasmer-clif-backend",
- "wasmer-middleware-common",
- "wasmer-runtime-core",
- "wasmer-singlepass-backend",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56aa72ef104c5d634f2f9e84ef2c47e116c1d185fae13f196b97ca84b0a514f1"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460b9d20793543599308d22f5a1172c196e63a780c4e9aacb0b3f4f63d63ffe1"
-dependencies = [
- "byteorder",
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-entity",
- "log",
- "smallvec 1.2.0",
- "target-lexicon",
- "thiserror",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc70e4e8ccebd53a4f925147def857c9e9f7fe0fdbef4bb645a420473e012f50"
-dependencies = [
- "cranelift-codegen-shared",
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3992000be4d18df0fe332b7c42c120de896e8ec54cd7b6cfa050910a8c9f6e2f"
-
-[[package]]
-name = "cranelift-entity"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722957e05064d97a3157bf0976deed0f3e8ee4f8a4ce167a7c724ca63a4e8bd9"
-
-[[package]]
-name = "cranelift-native"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21398a0bc6ba389ea86964ac4a495426dd61080f2ddd306184777a8560fe9976"
-dependencies = [
- "cranelift-codegen",
- "raw-cpuid",
- "target-lexicon",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg 1.0.0",
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "maybe-uninit",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.0",
- "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -401,35 +267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dynasm"
-version = "0.5.2"
+name = "downcast-rs"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a814e1edeb85dd2a3c6fc0d6bf76d02ca5695d438c70ecee3d90774f3259c5"
-dependencies = [
- "bitflags",
- "byteorder",
- "lazy_static",
- "owning_ref",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a393aaeb4441a48bcf47b5b6155971f82cc1eb77e22855403ccc0415ac8328d"
-dependencies = [
- "byteorder",
- "memmap",
-]
-
-[[package]]
-name = "either"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
 
 [[package]]
 name = "enclave-ffi-types"
@@ -440,37 +281,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -505,7 +319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
  "ahash",
- "autocfg 0.1.7",
+ "autocfg",
 ]
 
 [[package]]
@@ -524,47 +338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
-name = "indexmap"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
-dependencies = [
- "autocfg 1.0.0",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-
-[[package]]
-name = "lock_api"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -585,12 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,91 +378,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
-dependencies = [
- "autocfg 1.0.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parking_lot"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "smallvec 1.2.0",
- "winapi",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -782,41 +484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
-dependencies = [
- "bitflags",
- "cc",
- "rustc_version",
-]
-
-[[package]]
-name = "rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
-dependencies = [
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,15 +503,6 @@ name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "ryu"
@@ -876,27 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,29 +543,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-bench"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
 name = "serde-json-wasm"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77cf509484e297252a195b1338a6d45843fe11ef234259f67649e8729934f443"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 dependencies = [
  "serde",
 ]
@@ -979,21 +597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-
-[[package]]
 name = "snafu"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,12 +617,6 @@ dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "strsim"
@@ -1054,12 +651,6 @@ dependencies = [
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
 
 [[package]]
 name = "tempfile"
@@ -1144,12 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "wabt"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,132 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasmer-clif-backend"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea74b659f78bffcc2db4bd77bf27ce66907ab76728d012346b130fe384e11399"
-dependencies = [
- "byteorder",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-native",
- "libc",
- "nix",
- "rayon",
- "serde",
- "serde-bench",
- "serde_bytes",
- "serde_derive",
- "target-lexicon",
- "wasmer-clif-fork-frontend",
- "wasmer-clif-fork-wasm",
- "wasmer-runtime-core",
- "wasmer-win-exception-handler",
- "wasmparser",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-clif-fork-frontend"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2e13201ef9ef527ad30a6bf1b08e3e024a40cf2731f393d80375dc88506207"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec 1.2.0",
- "target-lexicon",
-]
-
-[[package]]
-name = "wasmer-clif-fork-wasm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b09302cc4fdc4efc03823cb3e1880b0fde578ba43f27ddd212811cb28c1530"
-dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "log",
- "thiserror",
- "wasmer-clif-fork-frontend",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmer-middleware-common"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a15e6c615e8d3a8c6158acfb8cf4ca02cd8d174232a478c9df422505c2a2b5"
-dependencies = [
- "wasmer-runtime-core",
-]
-
-[[package]]
-name = "wasmer-runtime-core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af29c21b4b17c90035dc5bc6a4dcf018b16acfd745631c905f2a7f04e3e2c74e"
-dependencies = [
- "bincode",
- "blake3",
- "cc",
- "digest",
- "errno",
- "hex 0.4.2",
- "indexmap",
- "lazy_static",
- "libc",
- "nix",
- "page_size",
- "parking_lot",
- "rustc_version",
- "serde",
- "serde-bench",
- "serde_bytes",
- "serde_derive",
- "smallvec 0.6.13",
- "wasmparser",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-singlepass-backend"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa85672d65a4a338edb4a4ac6ccf7a6e080aa1930a55eba0cbcd5700e4dad06"
-dependencies = [
- "bincode",
- "byteorder",
- "dynasm",
- "dynasmrt",
- "lazy_static",
- "libc",
- "nix",
- "serde",
- "serde_derive",
- "smallvec 0.6.13",
- "wasmer-runtime-core",
-]
-
-[[package]]
-name = "wasmer-win-exception-handler"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5ede589f678bb6c061e173394506589fd2bae9165d841b218c5d07b3082cd4"
-dependencies = [
- "cmake",
- "libc",
- "wasmer-runtime-core",
- "winapi",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.45.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4eab1d9971d0803729cba3617b56eb04fcb4bd25361cb63880ed41a42f20d5"
-
-[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,25 +784,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x-cosmwasm-vm"
-version = "0.7.0"
-dependencies = [
- "cosmwasm",
- "hex 0.3.2",
- "lru",
- "memmap",
- "parity-wasm",
- "schemars",
- "serde",
- "serde-json-wasm",
- "sha2",
- "snafu",
- "tempfile",
- "wabt",
- "wasmer-clif-backend",
- "wasmer-middleware-common",
- "wasmer-runtime-core",
- "wasmer-singlepass-backend",
-]

--- a/cosmwasm/Cargo.toml
+++ b/cosmwasm/Cargo.toml
@@ -14,8 +14,9 @@ circle-ci = { repository = "confio/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [workspace]
-members = [ "lib/vm", "lib/sgx-vm" ]
-exclude = [ "contracts", "lib/wasmi-runtime", "lib/enclave-ffi-types"]
+members = [ "lib/sgx-vm" ]
+# lib/vm is kept as legacy for now, as reference to the original implementation.
+exclude = [ "contracts", "lib/vm", "lib/wasmi-runtime", "lib/enclave-ffi-types"]
 
 [dependencies]
 base64 = "0.11.0"

--- a/cosmwasm/lib/enclave-ffi-types/src/types.rs
+++ b/cosmwasm/lib/enclave-ffi-types/src/types.rs
@@ -14,7 +14,6 @@ pub struct EnclaveBuffer {
 
 /// This struct holds a pointer to memory in userspace, that contains the storage
 #[repr(C)]
-#[derive(Clone, Copy)]
 pub struct Ctx {
     pub data: *mut c_void,
 }
@@ -22,10 +21,17 @@ pub struct Ctx {
 /// This type represents the possible error conditions that can be encountered in the enclave
 /// cbindgen:prefix-with-name
 #[repr(C)]
+#[derive(Debug)]
 pub enum EnclaveError {
     InvalidWasm,
     WasmModuleWithStart,
     WasmModuleWithFP,
+}
+
+impl core::fmt::Display for EnclaveError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(formatter, "{:?}", self)
+    }
 }
 
 /// This struct is returned from ecall_init.

--- a/cosmwasm/lib/sgx-vm/Cargo.toml
+++ b/cosmwasm/lib/sgx-vm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "enigma-cosmwasm-sgx-vm"
+name = "cosmwasm-sgx-vm"
 version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Enigma Team <dev@enigma.co>"]
 edition = "2018"
@@ -7,13 +7,14 @@ description = "VM bindings to run cosmwams contracts inside an SGX enclave"
 repository = "https://github.com/enigmampc/EnigmaBlockchain/tree/master/cosmwasm/lib/sgx-vm"
 license = "Apache-2.0"
 
+[features]
+# enable this for better error reporting
+default = ["backtraces"]
+backtraces = ["snafu/backtraces"]
+
 [dependencies]
 cosmwasm = { path = "../..", version = "0.7.0" }
 serde-json-wasm = "0.1.0"
-#wasmer-runtime-core = "0.14.0"
-#wasmer-middleware-common = "0.14.0"
-#wasmer-clif-backend = {version = "0.14.0", optional = true }
-#wasmer-singlepass-backend = {version = "0.14.0", optional = true }
 schemars = "0.5"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
@@ -22,6 +23,9 @@ hex = "0.3.1"
 memmap = "0.7"
 lru = "0.3.1"
 parity-wasm = "0.41"
+blake3 = "0.1.0"
+downcast-rs = "1"
+enclave-ffi-types = { path = "../enclave-ffi-types" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/cosmwasm/lib/sgx-vm/src/calls.rs
+++ b/cosmwasm/lib/sgx-vm/src/calls.rs
@@ -1,11 +1,12 @@
 use snafu::ResultExt;
 
 use cosmwasm::serde::{from_slice, to_vec};
-use cosmwasm::traits::{Api, Storage};
+use cosmwasm::traits::Api;
 use cosmwasm::types::{ContractResult, Env, QueryResult};
 
-use crate::errors::{Error, ParseErr, RuntimeErr, SerializeErr};
-use crate::instance::{Func, Instance};
+use crate::errors::{Error, ParseErr, /*RuntimeErr,*/ SerializeErr};
+use crate::instance::Instance;
+use crate::Storage;
 
 pub fn call_init<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
@@ -42,14 +43,7 @@ pub fn call_query_raw<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    // we cannot resuse the call_raw functionality as it assumes a param variable... just do it inline
-    let msg_offset = instance.allocate(msg)?;
-    let func: Func<u32, u32> = instance.func("query")?;
-    let res_offset = func.call(msg_offset).context(RuntimeErr {})?;
-    let data = instance.memory(res_offset);
-    // free return value in wasm (arguments were freed in wasm code)
-    instance.deallocate(res_offset)?;
-    Ok(data)
+    instance.call_query(msg).into()
 }
 
 pub fn call_init_raw<S: Storage + 'static, A: Api + 'static>(
@@ -57,7 +51,7 @@ pub fn call_init_raw<S: Storage + 'static, A: Api + 'static>(
     env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    call_raw(instance, "init", env, msg)
+    instance.call_init(env, msg).into()
 }
 
 pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static>(
@@ -65,9 +59,10 @@ pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static>(
     env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    call_raw(instance, "handle", env, msg)
+    instance.call_handle(env, msg).into()
 }
 
+/*
 fn call_raw<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
     name: &str,
@@ -85,3 +80,4 @@ fn call_raw<S: Storage + 'static, A: Api + 'static>(
     instance.deallocate(res_offset)?;
     Ok(data)
 }
+*/

--- a/cosmwasm/lib/sgx-vm/src/errors.rs
+++ b/cosmwasm/lib/sgx-vm/src/errors.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 use std::io;
 
 use snafu::Snafu;
-use wasmer_runtime_core::cache::Error as CacheError;
-use wasmer_runtime_core::error as core_error;
+// use wasmer_runtime_core::cache::Error as CacheError;
+// use wasmer_runtime_core::error as core_error;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
@@ -14,12 +14,14 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    /*
     #[snafu(display("Compiling wasm: {}", source))]
     CompileErr {
         source: core_error::CompileError,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    */
     #[snafu(display("Filesystem error: {}", source))]
     IoErr {
         source: io::Error,
@@ -43,6 +45,7 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    /*
     #[snafu(display("Resolving wasm function: {}", source))]
     ResolveErr {
         source: core_error::ResolveError,
@@ -55,6 +58,7 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    */
     #[snafu(display("Region too small. Got {}, required {}", size, required))]
     RegionTooSmallErr {
         size: usize,
@@ -68,16 +72,23 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    /*
     #[snafu(display("Wasmer error: {}", source))]
     WasmerErr {
         source: core_error::Error,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    */
+    #[snafu(display("Enclave error: {}", inner))]
+    EnclaveErr {
+        inner: enclave_ffi_types::EnclaveError,
+    },
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
+/*
 pub trait CacheExt<T: Debug> {
     fn convert_cache(self) -> Result<T>;
 }
@@ -92,3 +103,4 @@ impl<T: Debug> CacheExt<T> for Result<T, CacheError> {
         })
     }
 }
+*/

--- a/cosmwasm/lib/sgx-vm/src/lib.rs
+++ b/cosmwasm/lib/sgx-vm/src/lib.rs
@@ -1,19 +1,21 @@
-mod backends;
 mod cache;
 mod calls;
 mod compatability;
 mod context;
 pub mod errors;
 mod instance;
-mod memory;
-mod middleware;
-mod modules;
-pub mod testing;
+// mod memory;
+// mod middleware;
+// mod modules;
+// pub mod testing;
+mod traits;
 mod wasm_store;
+mod wasmi;
 
 pub use crate::cache::CosmCache;
 pub use crate::calls::{
     call_handle, call_handle_raw, call_init, call_init_raw, call_query, call_query_raw,
 };
 pub use crate::instance::Instance;
-pub use crate::modules::FileSystemCache;
+// pub use crate::modules::FileSystemCache;
+pub use crate::traits::{Extern, ReadonlyStorage, Storage};

--- a/cosmwasm/lib/sgx-vm/src/traits.rs
+++ b/cosmwasm/lib/sgx-vm/src/traits.rs
@@ -1,0 +1,26 @@
+//! This module exists because we need to modify the `Storage` trait, defined originally in `cosmwasm`,
+//! in order to allow downcasting trait objects of this trait. Since the implementations of this trait outside and
+//! inside the wasm runtime are completely separate, we can replace the original trait for this one in the code of
+//! cosmwasm-sgx-vm.
+use cosmwasm::traits::Api;
+use downcast_rs::{impl_downcast, Downcast};
+
+// Extern holds all external dependencies of the contract,
+// designed to allow easy dependency injection at runtime
+#[derive(Clone)]
+pub struct Extern<S: Storage, A: Api> {
+    pub storage: S,
+    pub api: A,
+}
+
+// ReadonlyStorage is access to the contracts persistent data store
+//pub trait ReadonlyStorage: Clone {
+pub trait ReadonlyStorage: Downcast {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
+}
+
+// Storage extends ReadonlyStorage to give mutable access
+pub trait Storage: ReadonlyStorage {
+    fn set(&mut self, key: &[u8], value: &[u8]);
+}
+impl_downcast!(Storage);

--- a/cosmwasm/lib/sgx-vm/src/wasm_store.rs
+++ b/cosmwasm/lib/sgx-vm/src/wasm_store.rs
@@ -1,3 +1,6 @@
+//! This module exposes two simple methods, save and load, which just store binary blobs in a requested directory,
+//! with the filename of the blob equaling `hex(sha256(blob))`
+
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;

--- a/cosmwasm/lib/sgx-vm/src/wasmi/exports.rs
+++ b/cosmwasm/lib/sgx-vm/src/wasmi/exports.rs
@@ -1,8 +1,8 @@
 use std::ffi::c_void;
 
-use enclave_ffi_types::{
-    Ctx, EnclaveBuffer, UserSpaceBuffer,
-};
+use enclave_ffi_types::{Ctx, EnclaveBuffer, UserSpaceBuffer};
+
+use crate::context::with_storage_from_context;
 
 /// Copy a buffer from the enclave memory space, and return an opaque pointer to it.
 #[no_mangle]
@@ -17,7 +17,7 @@ pub extern "C" fn ocall_allocate(buffer: *const u8, length: usize) -> UserSpaceB
 }
 
 /// Take a pointer as returned by `ocall_allocate` and recover the Vec<u8> inside of it.
-pub unsafe fn recover_buffer(ptr: EnclaveBuffer) -> Option<Vec<u8>> {
+pub unsafe fn recover_buffer(ptr: UserSpaceBuffer) -> Option<Vec<u8>> {
     if ptr.ptr.is_null() {
         return None;
     }
@@ -28,26 +28,48 @@ pub unsafe fn recover_buffer(ptr: EnclaveBuffer) -> Option<Vec<u8>> {
 /// Read a key from the contracts key-value store.
 /// instance_id should be the sha256 of the wasm blob.
 #[no_mangle]
-pub extern "C" fn ocall_read_db(context: Ctx, key: *const u8, key_len: usize) -> EnclaveBuffer {
-    let _key = unsafe { std::slice::from_raw_parts(key, key_len) };
-    // also add panic handlers here
-    // how do we signal errors into the enclave? should we?
-    let value = todo!();
-    super::allocate_enclave_buffer(value)
+pub extern "C" fn ocall_read_db(mut context: Ctx, key: *const u8, key_len: usize) -> EnclaveBuffer {
+    let key = unsafe { std::slice::from_raw_parts(key, key_len) };
+
+    // Returning `EnclaveBuffer { ptr: std::ptr::null_mut() }` is basically returning a null pointer,
+    // which in the enclave is interpreted as signaling that the key does not exist.
+    // We also interpret this potential panic here as a missing key because we have no way of handling
+    // it at the moment.
+    // In the future, if we see that panics do occur here, we should add a way to report this to the enclave.
+    std::panic::catch_unwind(move || {
+        let mut value: Option<Vec<u8>> = None;
+        with_storage_from_context(&mut context, |storage| value = storage.get(key));
+        value
+    })
+    .map(|value| {
+        value
+            .map(|vec| super::allocate_enclave_buffer(&vec))
+            .unwrap_or(EnclaveBuffer {
+                ptr: std::ptr::null_mut(),
+            })
+    })
+    .unwrap_or(EnclaveBuffer {
+        // TODO add logging if we fail to write
+        ptr: std::ptr::null_mut(),
+    })
 }
 
 /// Write a value to the contracts key-value store.
 /// instance_id should be the sha256 of the wasm blob.
 #[no_mangle]
 pub extern "C" fn ocall_write_db(
-    context: Ctx,
+    mut context: Ctx,
     key: *const u8,
     key_len: usize,
     value: *const u8,
     value_len: usize,
 ) {
-    let _key = unsafe { std::slice::from_raw_parts(key, key_len) };
-    let _value = unsafe { std::slice::from_raw_parts(value, value_len) };
-    // also add panic handlers here
-    todo!()
+    let key = unsafe { std::slice::from_raw_parts(key, key_len) };
+    let value = unsafe { std::slice::from_raw_parts(value, value_len) };
+
+    // We explicitly ignore this potential panic here because we have no way of handling it at the moment.
+    // In the future, if we see that panics do occur here, we should add a way to report this to the enclave.
+    let _ = std::panic::catch_unwind(move || {
+        with_storage_from_context(&mut context, |storage| storage.set(key, value))
+    }); // TODO add logging if we fail to write
 }

--- a/cosmwasm/lib/sgx-vm/src/wasmi/results.rs
+++ b/cosmwasm/lib/sgx-vm/src/wasmi/results.rs
@@ -1,9 +1,9 @@
 use super::exports;
-use enclave_ffi_types::{EnclaveError, InitResult, HandleResult, QueryResult};
+use enclave_ffi_types::{EnclaveError, HandleResult, InitResult, QueryResult};
 
 /// This struct is returned from module initialization.
 pub struct InitSuccess {
-    /// A pointer to the output of the execution using `ocall_save_to_memory`
+    /// A pointer to the output of the execution
     output: Vec<u8>,
     /// The gas used by the execution.
     used_gas: u64,
@@ -16,6 +16,10 @@ impl InitSuccess {
         &self.output
     }
 
+    pub fn into_output(self) -> Vec<u8> {
+        self.output
+    }
+
     pub fn used_gas(&self) -> u64 {
         self.used_gas
     }
@@ -25,26 +29,24 @@ impl InitSuccess {
     }
 }
 
-impl std::convert::From<InitResult> for Result<InitSuccess, EnclaveError> {
-    fn from(other: InitResult) -> Self {
-        match other {
-            InitResult::Success {
-                output,
-                used_gas,
-                signature,
-            } => Ok(InitSuccess {
-                output: unsafe { exports::recover_buffer(output) },
-                used_gas,
-                signature,
-            }),
-            InitResult::Failure { err } => Err(err),
-        }
+pub fn init_result_to_result_initsuccess(other: InitResult) -> Result<InitSuccess, EnclaveError> {
+    match other {
+        InitResult::Success {
+            output,
+            used_gas,
+            signature,
+        } => Ok(InitSuccess {
+            output: unsafe { exports::recover_buffer(output) }.unwrap_or_else(|| Vec::new()),
+            used_gas,
+            signature,
+        }),
+        InitResult::Failure { err } => Err(err),
     }
 }
 
 /// This struct is returned from a handle method.
 pub struct HandleSuccess {
-    /// A pointer to the output of the execution using `ocall_save_to_memory`
+    /// A pointer to the output of the execution
     output: Vec<u8>,
     /// The gas used by the execution.
     used_gas: u64,
@@ -57,6 +59,10 @@ impl HandleSuccess {
         &self.output
     }
 
+    pub fn into_output(self) -> Vec<u8> {
+        self.output
+    }
+
     pub fn used_gas(&self) -> u64 {
         self.used_gas
     }
@@ -66,26 +72,26 @@ impl HandleSuccess {
     }
 }
 
-impl std::convert::From<HandleResult> for Result<HandleSuccess, EnclaveError> {
-    fn from(other: HandleResult) -> Self {
-        match other {
-            HandleResult::Success {
-                output,
-                used_gas,
-                signature,
-            } => Ok(HandleSuccess {
-                output: unsafe { exports::recover_buffer(output) },
-                used_gas,
-                signature,
-            }),
-            HandleResult::Failure { err } => Err(err),
-        }
+pub fn handle_result_to_result_handlesuccess(
+    other: HandleResult,
+) -> Result<HandleSuccess, EnclaveError> {
+    match other {
+        HandleResult::Success {
+            output,
+            used_gas,
+            signature,
+        } => Ok(HandleSuccess {
+            output: unsafe { exports::recover_buffer(output) }.unwrap_or_else(|| Vec::new()),
+            used_gas,
+            signature,
+        }),
+        HandleResult::Failure { err } => Err(err),
     }
 }
 
 /// This struct is returned from a query method.
 pub struct QuerySuccess {
-    /// A pointer to the output of the execution using `ocall_save_to_memory`
+    /// A pointer to the output of the execution
     output: Vec<u8>,
     /// The gas used by the execution.
     used_gas: u64,
@@ -98,6 +104,10 @@ impl QuerySuccess {
         &self.output
     }
 
+    pub fn into_output(self) -> Vec<u8> {
+        self.output
+    }
+
     pub fn used_gas(&self) -> u64 {
         self.used_gas
     }
@@ -107,19 +117,19 @@ impl QuerySuccess {
     }
 }
 
-impl std::convert::From<QueryResult> for Result<QuerySuccess, EnclaveError> {
-    fn from(other: QueryResult) -> Self {
-        match other {
-            QueryResult::Success {
-                output,
-                used_gas,
-                signature,
-            } => Ok(QuerySuccess {
-                output: unsafe { exports::recover_buffer(output) },
-                used_gas,
-                signature,
-            }),
-            QueryResult::Failure { err } => Err(err),
-        }
+pub fn query_result_to_result_querysuccess(
+    other: QueryResult,
+) -> Result<QuerySuccess, EnclaveError> {
+    match other {
+        QueryResult::Success {
+            output,
+            used_gas,
+            signature,
+        } => Ok(QuerySuccess {
+            output: unsafe { exports::recover_buffer(output) }.unwrap_or_else(|| Vec::new()),
+            used_gas,
+            signature,
+        }),
+        QueryResult::Failure { err } => Err(err),
     }
 }

--- a/cosmwasm/lib/sgx-vm/src/wasmi/wasm_hash.rs
+++ b/cosmwasm/lib/sgx-vm/src/wasmi/wasm_hash.rs
@@ -1,17 +1,21 @@
 //! Copied and modified from the `wasmer-runtime-core` crate.
 
 use serde::{Deserialize, Serialize};
-use snafu::Snafu;
 
-#[derive(Debug, Snafu)]
-struct DeserializeError {
-    #[snafu(display("Deserialization error: {}", msg))]
-    pub msg: String,
-}
+#[derive(Debug)]
+pub struct DeserializeError(String);
 
 impl DeserializeError {
     fn new(msg: String) -> Self {
-        Self { msg }
+        Self(msg)
+    }
+}
+
+impl std::error::Error for DeserializeError {}
+
+impl std::fmt::Display for DeserializeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "Deserialization error: {:?}", self.0)
     }
 }
 
@@ -39,11 +43,13 @@ impl WasmHash {
 
     /// Create the hexadecimal representation of the
     /// stored hash.
+    #[allow(dead_code)]
     pub fn encode(self) -> String {
         hex::encode(&self.into_array() as &[u8])
     }
 
     /// Create hash from hexadecimal representation
+    #[allow(dead_code)]
     pub fn decode(hex_str: &str) -> Result<Self> {
         let bytes = hex::decode(hex_str).map_err(|e| {
             DeserializeError::new(format!(

--- a/cosmwasm/lib/vm/.gitignore
+++ b/cosmwasm/lib/vm/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/go-cosmwasm/Cargo.lock
+++ b/go-cosmwasm/Cargo.lock
@@ -48,16 +48,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
-name = "autocfg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
 name = "backtrace"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -67,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
  "cc",
  "libc",
@@ -80,16 +74,6 @@ name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "bincode"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
-dependencies = [
- "byteorder",
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -153,11 +137,11 @@ checksum = "9daec6140ab4dcd38c3dd57e580b59a621172a526ac79f1527af760a55afeafd"
 dependencies = [
  "clap",
  "log",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "serde",
  "serde_json",
- "syn 1.0.16",
+ "syn 1.0.17",
  "tempfile",
  "toml",
 ]
@@ -170,11 +154,11 @@ checksum = "2db2df1ebc842c41fd2c4ae5b5a577faf63bd5151b953db752fc686812bee318"
 dependencies = [
  "clap",
  "log",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "serde",
  "serde_json",
- "syn 1.0.16",
+ "syn 1.0.17",
  "tempfile",
  "toml",
 ]
@@ -204,15 +188,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -253,13 +228,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-vm"
+name = "cosmwasm-sgx-vm"
 version = "0.7.0"
 dependencies = [
  "blake3",
  "cosmwasm",
+ "downcast-rs",
  "enclave-ffi-types",
- "hex 0.3.2",
+ "hex",
  "lru",
  "memmap",
  "parity-wasm",
@@ -268,9 +244,6 @@ dependencies = [
  "serde-json-wasm",
  "sha2",
  "snafu",
- "wasmer-middleware-common",
- "wasmer-runtime-core",
- "wasmer-singlepass-backend",
 ]
 
 [[package]]
@@ -299,29 +272,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dynasm"
-version = "0.5.2"
+name = "downcast-rs"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a814e1edeb85dd2a3c6fc0d6bf76d02ca5695d438c70ecee3d90774f3259c5"
-dependencies = [
- "bitflags",
- "byteorder",
- "lazy_static",
- "owning_ref",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a393aaeb4441a48bcf47b5b6155971f82cc1eb77e22855403ccc0415ac8328d"
-dependencies = [
- "byteorder",
- "memmap",
-]
+checksum = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
 
 [[package]]
 name = "enclave-ffi-types"
@@ -333,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -390,7 +344,7 @@ version = "0.7.0"
 dependencies = [
  "cbindgen 0.9.1",
  "cosmwasm",
- "cosmwasm-vm",
+ "cosmwasm-sgx-vm",
  "errno",
  "snafu",
 ]
@@ -402,14 +356,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
  "ahash",
- "autocfg 0.1.7",
+ "autocfg",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -421,47 +375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
-name = "indexmap"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
-dependencies = [
- "autocfg 1.0.0",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-
-[[package]]
-name = "lock_api"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -482,12 +405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,72 +415,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parking_lot"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "smallvec 1.2.0",
- "winapi",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -573,14 +434,9 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f918f2b601f93baa836c1c2945faef682ba5b6d4828ecb45eeb7cc3c71b811b4"
-dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
-]
+checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
 
 [[package]]
 name = "proc-macro2"
@@ -593,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -615,7 +471,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
 ]
 
 [[package]]
@@ -681,15 +537,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,32 +559,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab7f0b9b64633747a68dce4ed6318bbf30e3befe67df7624ad83abb7295c09"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "serde_derive_internals",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -746,16 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-bench"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
-dependencies = [
- "byteorder",
- "serde",
 ]
 
 [[package]]
@@ -768,23 +584,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -793,16 +600,16 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 dependencies = [
  "itoa",
  "ryu",
@@ -820,21 +627,6 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
-
-[[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "snafu"
@@ -857,12 +649,6 @@ dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "strsim"
@@ -889,11 +675,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -923,22 +709,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -981,78 +767,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasmer-middleware-common"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a15e6c615e8d3a8c6158acfb8cf4ca02cd8d174232a478c9df422505c2a2b5"
-dependencies = [
- "wasmer-runtime-core",
-]
-
-[[package]]
-name = "wasmer-runtime-core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af29c21b4b17c90035dc5bc6a4dcf018b16acfd745631c905f2a7f04e3e2c74e"
-dependencies = [
- "bincode",
- "blake3",
- "cc",
- "digest",
- "errno",
- "hex 0.4.2",
- "indexmap",
- "lazy_static",
- "libc",
- "nix",
- "page_size",
- "parking_lot",
- "rustc_version",
- "serde",
- "serde-bench",
- "serde_bytes",
- "serde_derive",
- "smallvec 0.6.13",
- "wasmparser",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-singlepass-backend"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa85672d65a4a338edb4a4ac6ccf7a6e080aa1930a55eba0cbcd5700e4dad06"
-dependencies = [
- "bincode",
- "byteorder",
- "dynasm",
- "dynasmrt",
- "lazy_static",
- "libc",
- "nix",
- "serde",
- "serde_derive",
- "smallvec 0.6.13",
- "wasmer-runtime-core",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.45.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4eab1d9971d0803729cba3617b56eb04fcb4bd25361cb63880ed41a42f20d5"
 
 [[package]]
 name = "winapi"

--- a/go-cosmwasm/Cargo.toml
+++ b/go-cosmwasm/Cargo.toml
@@ -18,20 +18,14 @@ circle-ci = { repository = "confio/go-cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
-#default = ["singlepass", "backtraces"]
+default = ["backtraces"]
 backtraces = ["snafu/backtraces"]
-#singlepass = ["cosmwasm-vm/default-singlepass"]
-#cranelift = ["cosmwasm-vm/default-cranelift"]
 
 [dependencies]
-cosmwasm = "0.7.0"
-cosmwasm-vm = "0.7.0"
+cosmwasm = { path = "../cosmwasm" }
+cosmwasm-sgx-vm = { path = "../cosmwasm/lib/sgx-vm" }
 errno = "0.2"
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
-
-[patch.crates-io]
-cosmwasm = { path = "../cosmwasm" }
-cosmwasm-vm = { path = "../cosmwasm/lib/sgx-vm" }
 
 [build-dependencies]
 cbindgen = { version = "0.9.1" }

--- a/go-cosmwasm/src/db.rs
+++ b/go-cosmwasm/src/db.rs
@@ -1,4 +1,4 @@
-use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cosmwasm_sgx_vm::{ReadonlyStorage, Storage};
 
 use crate::memory::Buffer;
 

--- a/go-cosmwasm/src/error.rs
+++ b/go-cosmwasm/src/error.rs
@@ -1,7 +1,7 @@
 use errno::{set_errno, Errno};
 use std::fmt::{Debug, Display};
 
-use cosmwasm_vm::errors::Error as CosmWasmError;
+use cosmwasm_sgx_vm::errors::Error as CosmWasmError;
 use snafu::Snafu;
 
 use crate::memory::Buffer;

--- a/go-cosmwasm/src/lib.rs
+++ b/go-cosmwasm/src/lib.rs
@@ -13,8 +13,8 @@ use std::str::from_utf8;
 
 use crate::error::{clear_error, handle_c_error, set_error};
 use crate::error::{empty_err, EmptyArg, Error, Panic, Utf8Err, WasmErr};
-use cosmwasm::traits::Extern;
-use cosmwasm_vm::{call_handle_raw, call_init_raw, call_query_raw, CosmCache};
+// use cosmwasm::traits::Extern;
+use cosmwasm_sgx_vm::{call_handle_raw, call_init_raw, call_query_raw, CosmCache, Extern};
 
 #[repr(C)]
 pub struct cache_t {}


### PR DESCRIPTION
This PR implements all the changes in sgx-vm and go-cosmwasm required to use the enclave correctly, instead of wasmer.